### PR TITLE
ref: Refactor public API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ xref:
 	$(REBAR) xref
 
 lint:
-	elvis rock -V
+	$(REBAR) lint
 
 check_format:
 	$(REBAR) fmt -c

--- a/rebar.config
+++ b/rebar.config
@@ -57,7 +57,8 @@
 ]}.
 
 {plugins, [
-    {erlfmt, "0.10.0"}
+    {erlfmt, "1.0.0"},
+    {rebar3_lint, "1.0.0"}
 ]}.
 
 {erlfmt, [

--- a/src/bender_client.erl
+++ b/src/bender_client.erl
@@ -35,7 +35,7 @@
 gen_snowflake(IdempotentKey, WoodyContext) ->
     gen_snowflake(IdempotentKey, WoodyContext, undefined).
 
--spec gen_snowflake(binary(), woody_context(), bender_context()) -> result().
+-spec gen_snowflake(binary(), woody_context(), bender_context() | undefined) -> result().
 gen_snowflake(IdempotentKey, WoodyContext, Context) ->
     Snowflake = {snowflake, #bender_SnowflakeSchema{}},
     gen_id(IdempotentKey, Snowflake, WoodyContext, Context).
@@ -44,11 +44,11 @@ gen_snowflake(IdempotentKey, WoodyContext, Context) ->
 gen_sequence(IdempotentKey, SequenceID, WoodyContext) ->
     gen_sequence(IdempotentKey, SequenceID, WoodyContext, undefined).
 
--spec gen_sequence(binary(), binary(), woody_context(), bender_context()) -> result().
+-spec gen_sequence(binary(), binary(), woody_context(), bender_context() | undefined) -> result().
 gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context) ->
     gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, #{}).
 
--spec gen_sequence(binary(), binary(), woody_context(), bender_context(), sequence_params()) -> result().
+-spec gen_sequence(binary(), binary(), woody_context(), bender_context() | undefined, sequence_params()) -> result().
 gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, Params) ->
     Minimum = maps:get(minimum, Params, undefined),
     Sequence =
@@ -62,7 +62,7 @@ gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, Params) ->
 gen_constant(IdempotentKey, ConstantID, WoodyContext) ->
     gen_constant(IdempotentKey, ConstantID, WoodyContext, undefined).
 
--spec gen_constant(binary(), binary(), woody_context(), bender_context()) -> result().
+-spec gen_constant(binary(), binary(), woody_context(), bender_context() | undefined) -> result().
 gen_constant(IdempotentKey, ConstantID, WoodyContext, Context) ->
     Constant = {constant, #bender_ConstantSchema{internal_id = ConstantID}},
     gen_id(IdempotentKey, Constant, WoodyContext, Context).
@@ -98,7 +98,7 @@ gen_external_id() ->
 gen_id(Key, BenderSchema, WoodyContext) ->
     gen_id(Key, BenderSchema, WoodyContext, undefined).
 
--spec gen_id(binary(), bender_schema(), woody_context(), bender_context()) -> result().
+-spec gen_id(binary(), bender_schema(), woody_context(), bender_context() | undefined) -> result().
 gen_id(Key, BenderSchema, WoodyContext, Context) ->
     MarshalledContext = bender_msgp_marshalling:marshal(Context),
     Args = {Key, BenderSchema, MarshalledContext},

--- a/src/bender_client.erl
+++ b/src/bender_client.erl
@@ -29,8 +29,6 @@
 -export([get_idempotent_key/4]).
 -export([get_internal_id/2]).
 
--define(SCHEMA_VER1, 1).
-
 -spec gen_snowflake(binary(), woody_context()) -> result().
 gen_snowflake(IdempotentKey, WoodyContext) ->
     gen_snowflake(IdempotentKey, WoodyContext, undefined).
@@ -110,7 +108,7 @@ gen_id(Key, BenderSchema, WoodyContext, Context) ->
             {ok, InternalID};
         {ok, #bender_GenerationResult{
             internal_id = InternalID,
-            context = Context
+            context = SavedContext
         }} ->
-            {ok, InternalID, Context}
+            {ok, InternalID, SavedContext}
     end.

--- a/src/bender_client.erl
+++ b/src/bender_client.erl
@@ -3,15 +3,17 @@
 -include_lib("bender_proto/include/bender_thrift.hrl").
 
 -type woody_context() :: woody_context:ctx().
--type context_data() :: #{binary() => term()}.
 -type bender_context() :: #{binary() => term()}.
 -type sequence_params() :: #{minimum => integer()}.
--type generated_id() :: {binary(), integer() | undefined}.
+-type bender_schema() :: bender_thrift:'GenerationSchema'().
+-type id() :: binary().
+
+-type result() :: {ok, id()} | {ok, id(), bender_context()}.
 
 -export_type([
     bender_context/0,
-    context_data/0,
-    generated_id/0
+    bender_schema/0,
+    id/0
 ]).
 
 -export([gen_snowflake/2]).
@@ -21,39 +23,32 @@
 -export([gen_sequence/5]).
 -export([gen_constant/3]).
 -export([gen_constant/4]).
+-export([gen_id/3]).
+-export([gen_id/4]).
+
 -export([get_idempotent_key/4]).
 -export([get_internal_id/2]).
 
 -define(SCHEMA_VER1, 1).
 
--spec gen_snowflake(binary(), woody_context()) ->
-    {ok, generated_id()}
-    | {error, {external_id_conflict, generated_id()}}.
+-spec gen_snowflake(binary(), woody_context()) -> result().
 gen_snowflake(IdempotentKey, WoodyContext) ->
     gen_snowflake(IdempotentKey, WoodyContext, undefined).
 
--spec gen_snowflake(binary(), woody_context(), context_data()) ->
-    {ok, generated_id()}
-    | {error, {external_id_conflict, generated_id()}}.
+-spec gen_snowflake(binary(), woody_context(), bender_context()) -> result().
 gen_snowflake(IdempotentKey, WoodyContext, Context) ->
     Snowflake = {snowflake, #bender_SnowflakeSchema{}},
-    generate_id(IdempotentKey, Snowflake, WoodyContext, Context).
+    gen_id(IdempotentKey, Snowflake, WoodyContext, Context).
 
--spec gen_sequence(binary(), binary(), woody_context()) ->
-    {ok, generated_id()}
-    | {error, {external_id_conflict, generated_id()}}.
+-spec gen_sequence(binary(), binary(), woody_context()) -> result().
 gen_sequence(IdempotentKey, SequenceID, WoodyContext) ->
     gen_sequence(IdempotentKey, SequenceID, WoodyContext, undefined).
 
--spec gen_sequence(binary(), binary(), woody_context(), context_data()) ->
-    {ok, generated_id()}
-    | {error, {external_id_conflict, generated_id()}}.
+-spec gen_sequence(binary(), binary(), woody_context(), bender_context()) -> result().
 gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context) ->
     gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, #{}).
 
--spec gen_sequence(binary(), binary(), woody_context(), context_data(), sequence_params()) ->
-    {ok, generated_id()}
-    | {error, {external_id_conflict, generated_id()}}.
+-spec gen_sequence(binary(), binary(), woody_context(), bender_context(), sequence_params()) -> result().
 gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, Params) ->
     Minimum = maps:get(minimum, Params, undefined),
     Sequence =
@@ -61,20 +56,16 @@ gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, Params) ->
             sequence_id = SequenceID,
             minimum = Minimum
         }},
-    generate_id(IdempotentKey, Sequence, WoodyContext, Context).
+    gen_id(IdempotentKey, Sequence, WoodyContext, Context).
 
--spec gen_constant(binary(), binary(), woody_context()) ->
-    {ok, generated_id()}
-    | {error, {external_id_conflict, generated_id()}}.
+-spec gen_constant(binary(), binary(), woody_context()) -> result().
 gen_constant(IdempotentKey, ConstantID, WoodyContext) ->
     gen_constant(IdempotentKey, ConstantID, WoodyContext, undefined).
 
--spec gen_constant(binary(), binary(), woody_context(), context_data()) ->
-    {ok, generated_id()}
-    | {error, {external_id_conflict, generated_id()}}.
+-spec gen_constant(binary(), binary(), woody_context(), bender_context()) -> result().
 gen_constant(IdempotentKey, ConstantID, WoodyContext, Context) ->
     Constant = {constant, #bender_ConstantSchema{internal_id = ConstantID}},
-    generate_id(IdempotentKey, Constant, WoodyContext, Context).
+    gen_id(IdempotentKey, Constant, WoodyContext, Context).
 
 -spec get_idempotent_key(binary(), atom() | binary(), binary(), binary() | undefined) -> binary().
 get_idempotent_key(Domain, Prefix, PartyID, ExternalID) when is_atom(Prefix) ->
@@ -84,14 +75,16 @@ get_idempotent_key(Domain, Prefix, PartyID, undefined) ->
 get_idempotent_key(Domain, Prefix, PartyID, ExternalID) ->
     <<Domain/binary, "/", Prefix/binary, "/", PartyID/binary, "/", ExternalID/binary>>.
 
--spec get_internal_id(binary(), woody_context()) ->
-    {ok, binary(), context_data()}
-    | {error, internal_id_not_found}.
+-spec get_internal_id(binary(), woody_context()) -> result() | {error, internal_id_not_found}.
 get_internal_id(ExternalID, WoodyContext) ->
     case bender_client_woody:call('Bender', 'GetInternalID', {ExternalID}, WoodyContext) of
         {ok, #bender_GetInternalIDResult{internal_id = InternalID, context = Context}} ->
-            UnmarshaledCtx = bender_msgp_marshalling:unmarshal(Context),
-            {ok, InternalID, UnmarshaledCtx};
+            case bender_msgp_marshalling:unmarshal(Context) of
+                undefined ->
+                    {ok, InternalID};
+                UnmarshaledCtx ->
+                    {ok, InternalID, UnmarshaledCtx}
+            end;
         {exception, #bender_InternalIDNotFound{}} ->
             {error, internal_id_not_found}
     end.
@@ -101,7 +94,12 @@ get_internal_id(ExternalID, WoodyContext) ->
 gen_external_id() ->
     genlib:unique().
 
-generate_id(Key, BenderSchema, WoodyContext, Context) ->
+-spec gen_id(binary(), bender_schema(), woody_context()) -> result().
+gen_id(Key, BenderSchema, WoodyContext) ->
+    gen_id(Key, BenderSchema, WoodyContext, undefined).
+
+-spec gen_id(binary(), bender_schema(), woody_context(), bender_context()) -> result().
+gen_id(Key, BenderSchema, WoodyContext, Context) ->
     MarshalledContext = bender_msgp_marshalling:marshal(Context),
     Args = {Key, BenderSchema, MarshalledContext},
     case bender_client_woody:call('Bender', 'GenerateID', Args, WoodyContext) of

--- a/src/bender_client.erl
+++ b/src/bender_client.erl
@@ -14,67 +14,67 @@
     generated_id/0
 ]).
 
--export([gen_snowflake/4]).
+-export([gen_snowflake/2]).
 -export([gen_snowflake/3]).
+-export([gen_sequence/3]).
 -export([gen_sequence/4]).
 -export([gen_sequence/5]).
--export([gen_sequence/6]).
+-export([gen_constant/3]).
 -export([gen_constant/4]).
--export([gen_constant/5]).
 -export([get_idempotent_key/4]).
 -export([get_internal_id/2]).
 
 -define(SCHEMA_VER1, 1).
 
--spec gen_snowflake(binary(), integer(), woody_context()) ->
+-spec gen_snowflake(binary(), woody_context()) ->
     {ok, generated_id()}
     | {error, {external_id_conflict, generated_id()}}.
-gen_snowflake(IdempotentKey, Hash, WoodyContext) ->
-    gen_snowflake(IdempotentKey, Hash, WoodyContext, #{}).
+gen_snowflake(IdempotentKey, WoodyContext) ->
+    gen_snowflake(IdempotentKey, WoodyContext, undefined).
 
--spec gen_snowflake(binary(), integer(), woody_context(), context_data()) ->
+-spec gen_snowflake(binary(), woody_context(), context_data()) ->
     {ok, generated_id()}
     | {error, {external_id_conflict, generated_id()}}.
-gen_snowflake(IdempotentKey, Hash, WoodyContext, CtxData) ->
+gen_snowflake(IdempotentKey, WoodyContext, Context) ->
     Snowflake = {snowflake, #bender_SnowflakeSchema{}},
-    generate_id(IdempotentKey, Snowflake, Hash, WoodyContext, CtxData).
+    generate_id(IdempotentKey, Snowflake, WoodyContext, Context).
 
--spec gen_sequence(binary(), binary(), integer(), woody_context()) ->
+-spec gen_sequence(binary(), binary(), woody_context()) ->
     {ok, generated_id()}
     | {error, {external_id_conflict, generated_id()}}.
-gen_sequence(IdempotentKey, SequenceID, Hash, WoodyContext) ->
-    gen_sequence(IdempotentKey, SequenceID, Hash, WoodyContext, #{}).
+gen_sequence(IdempotentKey, SequenceID, WoodyContext) ->
+    gen_sequence(IdempotentKey, SequenceID, WoodyContext, undefined).
 
--spec gen_sequence(binary(), binary(), integer(), woody_context(), context_data()) ->
+-spec gen_sequence(binary(), binary(), woody_context(), context_data()) ->
     {ok, generated_id()}
     | {error, {external_id_conflict, generated_id()}}.
-gen_sequence(IdempotentKey, SequenceID, Hash, WoodyContext, CtxData) ->
-    gen_sequence(IdempotentKey, SequenceID, Hash, WoodyContext, CtxData, #{}).
+gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context) ->
+    gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, #{}).
 
--spec gen_sequence(binary(), binary(), integer(), woody_context(), context_data(), sequence_params()) ->
+-spec gen_sequence(binary(), binary(), woody_context(), context_data(), sequence_params()) ->
     {ok, generated_id()}
     | {error, {external_id_conflict, generated_id()}}.
-gen_sequence(IdempotentKey, SequenceID, Hash, WoodyContext, CtxData, Params) ->
+gen_sequence(IdempotentKey, SequenceID, WoodyContext, Context, Params) ->
     Minimum = maps:get(minimum, Params, undefined),
     Sequence =
         {sequence, #bender_SequenceSchema{
             sequence_id = SequenceID,
             minimum = Minimum
         }},
-    generate_id(IdempotentKey, Sequence, Hash, WoodyContext, CtxData).
+    generate_id(IdempotentKey, Sequence, WoodyContext, Context).
 
--spec gen_constant(binary(), binary(), integer(), woody_context()) ->
+-spec gen_constant(binary(), binary(), woody_context()) ->
     {ok, generated_id()}
     | {error, {external_id_conflict, generated_id()}}.
-gen_constant(IdempotentKey, ConstantID, Hash, WoodyContext) ->
-    gen_constant(IdempotentKey, ConstantID, Hash, WoodyContext, #{}).
+gen_constant(IdempotentKey, ConstantID, WoodyContext) ->
+    gen_constant(IdempotentKey, ConstantID, WoodyContext, undefined).
 
--spec gen_constant(binary(), binary(), integer(), woody_context(), context_data()) ->
+-spec gen_constant(binary(), binary(), woody_context(), context_data()) ->
     {ok, generated_id()}
     | {error, {external_id_conflict, generated_id()}}.
-gen_constant(IdempotentKey, ConstantID, Hash, WoodyContext, CtxData) ->
+gen_constant(IdempotentKey, ConstantID, WoodyContext, Context) ->
     Constant = {constant, #bender_ConstantSchema{internal_id = ConstantID}},
-    generate_id(IdempotentKey, Constant, Hash, WoodyContext, CtxData).
+    generate_id(IdempotentKey, Constant, WoodyContext, Context).
 
 -spec get_idempotent_key(binary(), atom() | binary(), binary(), binary() | undefined) -> binary().
 get_idempotent_key(Domain, Prefix, PartyID, ExternalID) when is_atom(Prefix) ->
@@ -85,17 +85,13 @@ get_idempotent_key(Domain, Prefix, PartyID, ExternalID) ->
     <<Domain/binary, "/", Prefix/binary, "/", PartyID/binary, "/", ExternalID/binary>>.
 
 -spec get_internal_id(binary(), woody_context()) ->
-    {ok, {binary(), integer() | undefined}, context_data()}
+    {ok, binary(), context_data()}
     | {error, internal_id_not_found}.
 get_internal_id(ExternalID, WoodyContext) ->
     case bender_client_woody:call('Bender', 'GetInternalID', {ExternalID}, WoodyContext) of
-        {ok, #bender_GetInternalIDResult{
-            internal_id = InternalID,
-            integer_internal_id = IntegerInternalID,
-            context = Context
-        }} ->
+        {ok, #bender_GetInternalIDResult{internal_id = InternalID, context = Context}} ->
             UnmarshaledCtx = bender_msgp_marshalling:unmarshal(Context),
-            {ok, {InternalID, IntegerInternalID}, get_context_data(UnmarshaledCtx)};
+            {ok, InternalID, UnmarshaledCtx};
         {exception, #bender_InternalIDNotFound{}} ->
             {error, internal_id_not_found}
     end.
@@ -105,35 +101,18 @@ get_internal_id(ExternalID, WoodyContext) ->
 gen_external_id() ->
     genlib:unique().
 
-generate_id(Key, BenderSchema, Hash, WoodyContext, CtxData) ->
-    Context = bender_msgp_marshalling:marshal(#{
-        <<"version">> => ?SCHEMA_VER1,
-        <<"params_hash">> => Hash,
-        <<"context_data">> => CtxData
-    }),
-    Args = {Key, BenderSchema, Context},
-    Result =
-        case bender_client_woody:call('Bender', 'GenerateID', Args, WoodyContext) of
-            {ok, #bender_GenerationResult{
-                internal_id = InternalID,
-                integer_internal_id = IntegerInternalID,
-                context = undefined
-            }} ->
-                {ok, {InternalID, IntegerInternalID}};
-            {ok, #bender_GenerationResult{
-                internal_id = InternalID,
-                integer_internal_id = IntegerInternalID,
-                context = Ctx
-            }} ->
-                #{<<"params_hash">> := BenderHash} = bender_msgp_marshalling:unmarshal(Ctx),
-                {ok, {InternalID, IntegerInternalID}, BenderHash}
-        end,
-    case Result of
-        {ok, ID} -> {ok, ID};
-        {ok, ID, Hash} -> {ok, ID};
-        {ok, ID, _Other} -> {error, {external_id_conflict, ID}}
+generate_id(Key, BenderSchema, WoodyContext, Context) ->
+    MarshalledContext = bender_msgp_marshalling:marshal(Context),
+    Args = {Key, BenderSchema, MarshalledContext},
+    case bender_client_woody:call('Bender', 'GenerateID', Args, WoodyContext) of
+        {ok, #bender_GenerationResult{
+            internal_id = InternalID,
+            context = undefined
+        }} ->
+            {ok, InternalID};
+        {ok, #bender_GenerationResult{
+            internal_id = InternalID,
+            context = Context
+        }} ->
+            {ok, InternalID, Context}
     end.
-
--spec get_context_data(bender_context()) -> undefined | context_data().
-get_context_data(Context) ->
-    maps:get(<<"context_data">>, Context, #{}).

--- a/src/bender_client.erl
+++ b/src/bender_client.erl
@@ -110,5 +110,5 @@ gen_id(Key, BenderSchema, WoodyContext, Context) ->
             internal_id = InternalID,
             context = SavedContext
         }} ->
-            {ok, InternalID, SavedContext}
+            {ok, InternalID, bender_msgp_marshalling:unmarshal(SavedContext)}
     end.

--- a/src/bender_generator_client.erl
+++ b/src/bender_generator_client.erl
@@ -14,11 +14,11 @@ gen_snowflake(WoodyContext) ->
     Snowflake = {snowflake, #bender_SnowflakeSchema{}},
     generate_id(Snowflake, WoodyContext).
 
--spec gen_sequence(binary(), woody_context()) -> {ok, binary()}.
+-spec gen_sequence(binary(), woody_context()) -> binary().
 gen_sequence(SequenceID, WoodyContext) ->
     gen_sequence(SequenceID, WoodyContext, #{}).
 
--spec gen_sequence(binary(), woody_context(), sequence_params()) -> {ok, binary()}.
+-spec gen_sequence(binary(), woody_context(), sequence_params()) -> binary().
 gen_sequence(SequenceID, WoodyContext, Params) ->
     Minimum = maps:get(minimum, Params, undefined),
     Sequence =
@@ -34,4 +34,4 @@ generate_id(BenderSchema, WoodyContext) ->
     Args = {BenderSchema},
     {ok, #bender_GeneratedID{id = ID}} =
         bender_client_woody:call('Generator', 'GenerateID', Args, WoodyContext),
-    {ok, ID}.
+    ID.

--- a/src/bender_generator_client.erl
+++ b/src/bender_generator_client.erl
@@ -9,7 +9,7 @@
 -type woody_context() :: woody_context:ctx().
 -type sequence_params() :: #{minimum => integer()}.
 
--spec gen_snowflake(woody_context()) -> {ok, binary()}.
+-spec gen_snowflake(woody_context()) -> binary().
 gen_snowflake(WoodyContext) ->
     Snowflake = {snowflake, #bender_SnowflakeSchema{}},
     generate_id(Snowflake, WoodyContext).

--- a/src/bender_generator_client.erl
+++ b/src/bender_generator_client.erl
@@ -9,16 +9,16 @@
 -type woody_context() :: woody_context:ctx().
 -type sequence_params() :: #{minimum => integer()}.
 
--spec gen_snowflake(woody_context()) -> {ok, {binary(), integer() | undefined}}.
+-spec gen_snowflake(woody_context()) -> {ok, binary()}.
 gen_snowflake(WoodyContext) ->
     Snowflake = {snowflake, #bender_SnowflakeSchema{}},
     generate_id(Snowflake, WoodyContext).
 
--spec gen_sequence(binary(), woody_context()) -> {ok, {binary(), integer() | undefined}}.
+-spec gen_sequence(binary(), woody_context()) -> {ok, binary()}.
 gen_sequence(SequenceID, WoodyContext) ->
     gen_sequence(SequenceID, WoodyContext, #{}).
 
--spec gen_sequence(binary(), woody_context(), sequence_params()) -> {ok, {binary(), integer() | undefined}}.
+-spec gen_sequence(binary(), woody_context(), sequence_params()) -> {ok, binary()}.
 gen_sequence(SequenceID, WoodyContext, Params) ->
     Minimum = maps:get(minimum, Params, undefined),
     Sequence =
@@ -32,6 +32,6 @@ gen_sequence(SequenceID, WoodyContext, Params) ->
 
 generate_id(BenderSchema, WoodyContext) ->
     Args = {BenderSchema},
-    {ok, #bender_GeneratedID{id = ID, integer_id = IntegerID}} =
+    {ok, #bender_GeneratedID{id = ID}} =
         bender_client_woody:call('Generator', 'GenerateID', Args, WoodyContext),
-    {ok, {ID, IntegerID}}.
+    {ok, ID}.

--- a/test/bender_client_SUITE.erl
+++ b/test/bender_client_SUITE.erl
@@ -10,10 +10,10 @@
 -export([end_per_suite/1]).
 
 -export([
-    gen_internal_id/1,
+    sequence/1,
     get_internal_id/1,
-    snowflake/1,
-    sequence/1
+    generator_snowflake/1,
+    generator_sequence/1
 ]).
 
 -type test_case_name() :: atom().
@@ -29,12 +29,12 @@ all() ->
 groups() ->
     [
         {all_tests, [sequence], [
-            gen_internal_id,
+            sequence,
             get_internal_id
         ]},
         {no_external_id, [], [
-            snowflake,
-            sequence
+            generator_snowflake,
+            generator_sequence
         ]}
     ].
 
@@ -66,31 +66,31 @@ end_per_suite(Config) ->
 
 -define(EXTERNAL_ID, <<"external_id">>).
 
--spec gen_internal_id(config()) -> _.
-gen_internal_id(_) ->
+-spec sequence(config()) -> _.
+sequence(_) ->
     WoodyContext = woody_context:new(),
     IdempotentKey = get_idempotent_key(?EXTERNAL_ID),
-    {ok, {<<"1">>, 1}} = bender_client:gen_sequence(IdempotentKey, <<"SEQ">>, erlang:phash2(<<"HASH">>), WoodyContext).
+    {ok, <<"1">>} = bender_client:gen_sequence(IdempotentKey, <<"SEQ">>, WoodyContext).
 
 -spec get_internal_id(config()) -> _.
 get_internal_id(_) ->
     WoodyContext = woody_context:new(),
     IdempotentKey = get_idempotent_key(?EXTERNAL_ID),
-    {ok, {<<"1">>, 1}, _} = bender_client:get_internal_id(IdempotentKey, WoodyContext).
+    {ok, <<"1">>, _} = bender_client:get_internal_id(IdempotentKey, WoodyContext).
 
--spec snowflake(config()) -> _.
-snowflake(_) ->
+-spec generator_snowflake(config()) -> _.
+generator_snowflake(_) ->
     WoodyContext = woody_context:new(),
-    {ok, {_ID, _IntegerID}} = bender_generator_client:gen_snowflake(WoodyContext).
+    {ok, _ID} = bender_generator_client:gen_snowflake(WoodyContext).
 
--spec sequence(config()) -> _.
-sequence(_) ->
+-spec generator_sequence(config()) -> _.
+generator_sequence(_) ->
     WoodyContext = woody_context:new(),
     SequenceID = genlib:unique(),
-    {ok, {<<"1">>, 1}} = bender_generator_client:gen_sequence(SequenceID, WoodyContext),
-    {ok, {<<"2">>, 2}} = bender_generator_client:gen_sequence(SequenceID, WoodyContext),
-    {ok, {<<"4">>, 4}} = bender_generator_client:gen_sequence(SequenceID, WoodyContext, #{minimum => 4}),
-    {ok, {<<"5">>, 5}} = bender_generator_client:gen_sequence(SequenceID, WoodyContext).
+    {ok, <<"1">>} = bender_generator_client:gen_sequence(SequenceID, WoodyContext),
+    {ok, <<"2">>} = bender_generator_client:gen_sequence(SequenceID, WoodyContext),
+    {ok, <<"4">>} = bender_generator_client:gen_sequence(SequenceID, WoodyContext, #{minimum => 4}),
+    {ok, <<"5">>} = bender_generator_client:gen_sequence(SequenceID, WoodyContext).
 
 get_idempotent_key(ExternalID) ->
     bender_client:get_idempotent_key(<<"domain">>, <<"prefix">>, <<"party">>, ExternalID).

--- a/test/bender_client_SUITE.erl
+++ b/test/bender_client_SUITE.erl
@@ -87,7 +87,8 @@ get_internal_id(_) ->
 sequence_w_context(_) ->
     WoodyContext = woody_context:new(),
     IdempotentKey = get_idempotent_key(?EXTERNAL_ID_2),
-    {ok, <<"2">>} = bender_client:gen_sequence(IdempotentKey, <<"SEQ">>, WoodyContext, #{<<"key">> => <<"my_context">>}).
+    Context = #{<<"key">> => <<"my_context">>},
+    {ok, <<"2">>} = bender_client:gen_sequence(IdempotentKey, <<"SEQ">>, WoodyContext, Context).
 
 -spec get_internal_id_w_context(config()) -> _.
 get_internal_id_w_context(_) ->


### PR DESCRIPTION
В процессе перенесения bender-related функциональности из capi в wapi обнаружил, что текущее API несколько негибкое и устаревшее, из-за чего [capi и вовсе ходит в bender в обход клиента](https://github.com/rbkmoney/erlang_capi_v2/blob/aa081138dc2be590810d59102d8677cb077b42eb/apps/capi/src/capi_bender.erl#L240).

# Решаемые проблемы

1. В текущей и новой версии идемпотентности в capi отсутствует валидация по хэшам (этого же стоит ожидать и для wapi). **Решение:** убрать проверку хэша из библиотеки вовсе: в случае необходимости она без проблем добавляется поверх клиента. 
2. Клиент оборачивает пользовательский контекст в собственный с указанием "версии" (клиента) и хэша. Хэш убирается исходя из п.1, а [версия никак не используется самим бендером](https://github.com/rbkmoney/bender/search?l=Text&q=version) и не имеет смысла в отрыве от пользовательского кода (напр. версия контекста). **Решение**: удалить ненужные поля и дать пользователю библиотеки возможность указания полного контекста, добавляя необходимую функциональность поверх (напр. [валидация контекста в зависимости от польз. версии, как это сделано в capi](https://github.com/rbkmoney/erlang_capi_v2/blob/aa081138dc2be590810d59102d8677cb077b42eb/apps/capi/src/capi_bender.erl#L249-L252))
 3. Исторически результат вызова в `bender` [*может* вернуть целочисленное представление ID](https://github.com/rbkmoney/bender-proto/blob/75be9417ba704326c5711f935f8745d504d92935/proto/bender.thrift#L33), однако данная функциональность нигде не используется (см. ссылки ниже). **Решение**: возвращение только строкого представления ID для упрощения API.
 
- https://github.com/search?q=org%3Arbkmoney+bender_client&type=Code
- https://github.com/search?q=org%3Arbkmoney+bender_generator_client&type=Code
 
 # Миграция
 
 [`bender_client`](https://github.com/search?q=org%3Arbkmoney+bender_client&type=Code) и [`bender_generator_client` ](https://github.com/search?q=org%3Arbkmoney+bender_generator_client&type=Code)используются редко и ограничиваются `capi-v2` и `wapi`, поэтому проблем с миграцией не предвидется.
 
